### PR TITLE
When looking for visible elements it should look into iframes, too

### DIFF
--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -85,12 +85,14 @@ function selectVisibleElements(selector) {
     });
 
     document.querySelectorAll('iframe').forEach(function(iframe) {
-        iframe.contentWindow.document.body.querySelectorAll(selector).forEach(function(element) {
-        var elementStyle = window.getComputedStyle(element);
-            if (isVisible(element)) {
-                visibleElements.push(element);
-            }
-        });
+        if (iframe.src.startsWith(window.location.origin)) {
+            iframe.contentWindow.document.body.querySelectorAll(selector).forEach(function(element) {
+                var elementStyle = window.getComputedStyle(element);
+                if (isVisible(element)) {
+                    visibleElements.push(element);
+                }
+            });
+        }
     });
 
     return visibleElements;

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -87,16 +87,9 @@ function selectVisibleElements(selector) {
     document.querySelectorAll('iframe').forEach(function(iframe) {
         iframe.contentWindow.document.body.querySelectorAll(selector).forEach(function(element) {
         var elementStyle = window.getComputedStyle(element);
-            if (element.offsetWidth < 50) {
-                return;
+            if (isVisible(element)) {
+                visibleElements.push(element);
             }
-            if (element.offsetHeight < 10) {
-                return;
-            }
-            if (elementStyle.visibility === 'hidden') {
-                return;
-            }
-            visibleElements.push(element);
         });
     });
 

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -59,24 +59,47 @@ var inputEventNames = ['click', 'focus', 'keypress', 'keydown', 'keyup', 'input'
                 idstr
             );
         })
-        .join(',');
+    .join(',');
+
+function isVisible(element) {
+    var elementStyle = window.getComputedStyle(element);
+    if (element.offsetWidth < 50) {
+        return false;
+    }
+    if (element.offsetHeight < 10) {
+        return false;
+    }
+    if (elementStyle.visibility === 'hidden') {
+        return false;
+    }
+    return true;
+}
 
 function selectVisibleElements(selector) {
     var visibleElements = [];
 
     document.querySelectorAll(selector).forEach(function(element) {
-        var elementStyle = window.getComputedStyle(element);
-        if (element.offsetWidth < 50) {
-            return;
+        if (isVisible(element)) {
+                visibleElements.push(element);
         }
-        if (element.offsetHeight < 10) {
-            return;
-        }
-        if (elementStyle.visibility === 'hidden') {
-            return;
-        }
-        visibleElements.push(element);
     });
+
+    document.querySelectorAll('iframe').forEach(function(iframe) {
+        iframe.contentWindow.document.body.querySelectorAll(selector).forEach(function(element) {
+        var elementStyle = window.getComputedStyle(element);
+            if (element.offsetWidth < 50) {
+                return;
+            }
+            if (element.offsetHeight < 10) {
+                return;
+            }
+            if (elementStyle.visibility === 'hidden') {
+                return;
+            }
+            visibleElements.push(element);
+        });
+    });
+
     return visibleElements;
 }
 


### PR DESCRIPTION
Hello,

I've noticed many websites use iframes to show login forms and gopassbridge wasn't working with those.
One quick example is the pop-up shown on Twitter when you try to enable 2FA.

This PR should fix this. We could make it more secure by only looking for iframes with an SRC on the same domain as the main window.

Let me know what you think about it.

Take care!