### PR TITLE
Fix autofocus on firefox

### DIFF
--- a/web-extension/search.js
+++ b/web-extension/search.js
@@ -5,7 +5,10 @@ var searching, searchedUrl, searchTerm;
 var input = document.getElementById('search_input');
 
 input.addEventListener('input', onInputEvent);
-input.focus();
+
+setTimeout(() => {
+    input.focus();
+}, 100);
 
 function faviconUrl() {
     if (currentTab && currentTab.favIconUrl && currentTab.favIconUrl.indexOf(urlDomain(currentTab.url)) > -1) {


### PR DESCRIPTION
Add timeout for the autofocus of the search input field. This is
necessary for the focus to work in firefox.

Fixes #28 

See also
https://bugzilla.mozilla.org/show_bug.cgi?id=1338909